### PR TITLE
Allow scoped allocation

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -6,7 +6,7 @@ extern crate lifeguard;
 mod tests {
   use test::Bencher;
   use test::black_box;
-  use lifeguard::{Pool,Recycled};
+  use lifeguard::{Pool,RcRecycled};
 
   const ITERATIONS : u32 = 10_000;
 
@@ -29,8 +29,22 @@ mod tests {
   }
 
   #[bench]
-  fn bench02_pooled_allocation_speed(b: &mut Bencher) {
-    let mut pool : Pool<String> = Pool::with_size(5);
+  fn bench02_pooled_allocation_speed_rc(b: &mut Bencher) {
+    let pool : Pool<String> = Pool::with_size(5);
+    b.iter(|| {
+      for _ in 0..ITERATIONS {
+        let _string = pool.new_rc();
+        let _string = pool.new_rc();
+        let _string = pool.new_rc();
+        let _string = pool.new_rc();
+        let _string = pool.new_rc();
+      }
+    });
+  }
+
+  #[bench]
+  fn bench02_pooled_allocation_speed_scoped(b: &mut Bencher) {
+    let pool : Pool<String> = Pool::with_size(5);
     b.iter(|| {
       for _ in 0..ITERATIONS {
         let _string = pool.new();
@@ -57,14 +71,14 @@ mod tests {
 
   #[bench]
   fn bench04_pooled_initialized_allocation_speed(b: &mut Bencher) {
-    let mut pool : Pool<String> = Pool::with_size(5);
+    let pool : Pool<String> = Pool::with_size(5);
     b.iter(|| {
       for _ in 0..ITERATIONS {
-        let _string = pool.new_from("man");
-        let _string = pool.new_from("dog");
-        let _string = pool.new_from("cat");
-        let _string = pool.new_from("mouse");
-        let _string = pool.new_from("cheese");
+        let _string = pool.new_rc_from("man");
+        let _string = pool.new_rc_from("dog");
+        let _string = pool.new_rc_from("cat");
+        let _string = pool.new_rc_from("mouse");
+        let _string = pool.new_rc_from("cheese");
       }
     });
   }
@@ -85,14 +99,14 @@ mod tests {
 
   #[bench]
   fn bench06_pooled_vec_vec_str(bencher: &mut Bencher) {
-      let mut vec_str_pool : Pool<Vec<Recycled<String>>> = Pool::with_size(100);
-      let mut str_pool : Pool<String> = Pool::with_size(10000);
+      let vec_str_pool : Pool<Vec<RcRecycled<String>>> = Pool::with_size(100);
+      let str_pool : Pool<String> = Pool::with_size(10000);
       bencher.iter(|| {
           let mut v1 = Vec::new();
           for _ in 0..100 {
-              let mut v2 = vec_str_pool.new();
+              let mut v2 = vec_str_pool.new_rc();
               for _ in 0..100 {
-                  v2.push(str_pool.new_from("test!"));
+                  v2.push(str_pool.new_rc_from("test!"));
               }
               v1.push(v2);
           }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use std::cell::RefCell;
 use std::fmt;
 use std::ops::{Drop, Deref, DerefMut};
 use std::convert::{AsRef, AsMut};
+use std::borrow::Borrow;
 
 pub trait Recycleable {
   fn new() -> Self;
@@ -44,22 +45,91 @@ impl <A> InitializeWith<A> for String where A : AsRef<str> {
   }
 }
 
-pub struct Recycled<T> where T : Recycleable {
-  pub value: Option<T>,
-  pool: Rc<RefCell<Vec<T>>>
+pub struct RcRecycled<T> where T: Recycleable {
+  value: RecycledInner<Rc<RefCell<Vec<T>>>, T>
 }
 
-impl <T> Drop for Recycled<T> where T : Recycleable {
+pub struct Recycled<'a, T: 'a> where T: Recycleable {
+  value: RecycledInner<&'a RefCell<Vec<T>>, T>
+}
+
+macro_rules! impl_recycled {
+  ($name: ident, $typ: ty, $pool: ty) => {
+  impl <'a, T> AsRef<T> for $typ where T : Recycleable {
+     fn as_ref(&self) -> &T {
+      self.value.as_ref()
+    }
+  }
+
+  impl <'a, T> AsMut<T> for $typ where T : Recycleable {
+     fn as_mut(&mut self) -> &mut T {
+      self.value.as_mut()
+    }
+  }
+
+  impl <'a, T> fmt::Debug for $typ where T : fmt::Debug + Recycleable {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+      self.value.fmt(f)
+    }
+  }
+
+  impl <'a, T> fmt::Display for $typ where T : fmt::Display + Recycleable {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+      self.value.fmt(f)
+    }
+  }
+
+  impl <'a, T> Deref for $typ where T : Recycleable {
+    type Target = T;
+    #[inline] 
+    fn deref(&self) -> &T {
+      self.as_ref()
+    }
+  }
+
+  impl <'a, T> DerefMut for $typ where T : Recycleable {
+    #[inline] 
+    fn deref_mut(&mut self) -> &mut T {
+      self.as_mut()
+    }
+  }
+
+  impl <'a, T> $typ where T: Recycleable {
+    pub fn new(pool: $pool, value: T) -> $typ {
+      $name { value: RecycledInner::new(pool, value) }
+    }
+    
+    #[inline] 
+    pub fn new_from<A>(pool: $pool, value: T, source: A) -> $typ where T : InitializeWith<A> {
+      $name { value: RecycledInner::new_from(pool, value, source) }
+    }
+
+    #[inline] 
+    pub fn detach(self) -> T {
+      self.value.detach()
+    }
+  }
+}
+}
+impl_recycled!{ RcRecycled, RcRecycled<T>, Rc<RefCell<Vec<T>>> }
+impl_recycled!{ Recycled, Recycled<'a, T>, &'a RefCell<Vec<T>> }
+
+struct RecycledInner<P, T> where P: Borrow<RefCell<Vec<T>>>, T : Recycleable {
+  value: Option<T>,
+  pool: P
+}
+
+impl <P, T> Drop for RecycledInner<P, T> where P: Borrow<RefCell<Vec<T>>>, T : Recycleable {
   #[inline] 
   fn drop(&mut self) {
     if let Some(mut value) = self.value.take() {
       value.reset();
-      self.pool.borrow_mut().push(value);
+      self.pool.borrow().borrow_mut().push(value);
     }
   }
 }
 
-impl <T> AsRef<T> for Recycled<T> where T : Recycleable {
+impl <P, T> AsRef<T> for RecycledInner<P, T> where P: Borrow<RefCell<Vec<T>>>, T : Recycleable {
    fn as_ref(&self) -> &T {
     match self.value.as_ref() {
       Some(v) => v,
@@ -68,7 +138,7 @@ impl <T> AsRef<T> for Recycled<T> where T : Recycleable {
   }
 }
 
-impl <T> AsMut<T> for Recycled<T> where T : Recycleable {
+impl <P, T> AsMut<T> for RecycledInner<P, T> where P: Borrow<RefCell<Vec<T>>>, T : Recycleable {
    fn as_mut(&mut self) -> &mut T {
     match self.value.as_mut() {
       Some(v) => v,
@@ -77,7 +147,7 @@ impl <T> AsMut<T> for Recycled<T> where T : Recycleable {
   }
 }
 
-impl <T> fmt::Debug for Recycled<T> where T : fmt::Debug + Recycleable {
+impl <P, T> fmt::Debug for RecycledInner<P, T> where P: Borrow<RefCell<Vec<T>>>, T : fmt::Debug + Recycleable {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self.value {
       Some(ref s) => s.fmt(f),
@@ -86,7 +156,7 @@ impl <T> fmt::Debug for Recycled<T> where T : fmt::Debug + Recycleable {
   }
 }
 
-impl <T> fmt::Display for Recycled<T> where T : fmt::Display + Recycleable {
+impl <P, T> fmt::Display for RecycledInner<P, T> where P: Borrow<RefCell<Vec<T>>>, T : fmt::Display + Recycleable {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self.value {
       Some(ref s) => s.fmt(f),
@@ -95,7 +165,7 @@ impl <T> fmt::Display for Recycled<T> where T : fmt::Display + Recycleable {
   }
 }
 
-impl <T> Deref for Recycled<T> where T : Recycleable {
+impl <P, T> Deref for RecycledInner<P, T> where P: Borrow<RefCell<Vec<T>>>, T : Recycleable {
   type Target = T;
   #[inline] 
   fn deref<'a>(&'a self) -> &'a T {
@@ -103,33 +173,33 @@ impl <T> Deref for Recycled<T> where T : Recycleable {
   }
 }
 
-impl <T> DerefMut for Recycled<T> where T : Recycleable {
+impl <P, T> DerefMut for RecycledInner<P, T> where P: Borrow<RefCell<Vec<T>>>, T : Recycleable {
   #[inline] 
   fn deref_mut<'a>(&'a mut self) -> &'a mut T {
     self.as_mut()
   }
 }
 
-impl <T> Recycled<T> where T : Recycleable {
+impl <P, T> RecycledInner<P, T> where P: Borrow<RefCell<Vec<T>>>, T : Recycleable {
   #[inline] 
-  pub fn new(pool: Rc<RefCell<Vec<T>>>, value: T) -> Recycled<T> {
-    Recycled {
+  fn new(pool: P, value: T) -> RecycledInner<P, T> {
+    RecycledInner {
       value: Some(value),
       pool: pool
     }
   }
   
   #[inline] 
-  pub fn new_from<A>(pool: Rc<RefCell<Vec<T>>>, mut value: T, source: A) -> Recycled<T> where T : InitializeWith<A> {
+  fn new_from<A>(pool: P, mut value: T, source: A) -> RecycledInner<P, T> where T : InitializeWith<A> {
     value.initialize_with(source);
-    Recycled {
+    RecycledInner {
       value: Some(value),
       pool: pool
     }
   }
 
   #[inline] 
-  pub fn detach(mut self) -> T {
+  fn detach(mut self) -> T {
     let value = self.value.take().unwrap();
     drop(self);
     value
@@ -137,10 +207,12 @@ impl <T> Recycled<T> where T : Recycleable {
 }
 
 pub struct Pool <T> where T : Recycleable {
-  values: Rc<RefCell<Vec<T>>>,
+  values: Rc<RefCell<Vec<T>>>
 }
 
-impl <T> Pool <T> where T: Recycleable {
+impl <T> Pool <T>
+  where T: Recycleable {
+
   #[inline]
   pub fn with_size(size: u32) -> Pool <T> {
     let values: Vec<T> = 
@@ -148,18 +220,49 @@ impl <T> Pool <T> where T: Recycleable {
       .map(|_| T::new() )
       .collect();
     Pool {
-      values: Rc::new(RefCell::new(values)),
+      values: Rc::new(RefCell::new(values))
     }
   }
 
   #[inline] 
-  pub fn attach(&mut self, value: T) -> Recycled<T> {
+  pub fn attach_rc(&self, value: T) -> RcRecycled<T> {
     let pool_reference = self.values.clone();
-    Recycled::new(pool_reference, value)
+    RcRecycled { value: RecycledInner::new(pool_reference, value) }
   }
 
   #[inline] 
-  pub fn detached(&mut self) -> T {
+  pub fn new_rc(&self) -> RcRecycled<T> {
+    let t = self.detached();
+    let pool_reference = self.values.clone();
+    RcRecycled { value: RecycledInner::new(pool_reference, t) }
+  }
+ 
+  #[inline(always)] 
+  pub fn new_rc_from<A>(&self, source: A) -> RcRecycled<T> where T: InitializeWith<A> {
+    let t = self.detached();
+    let pool_reference = self.values.clone();
+    RcRecycled { value: RecycledInner::new_from(pool_reference, t, source) }
+  }
+
+  #[inline] 
+  pub fn attach(&self, value: T) -> Recycled<T> {
+    Recycled { value: RecycledInner::new(&*self.values, value) }
+  }
+
+  #[inline] 
+  pub fn new(&self) -> Recycled<T> {
+    let t = self.detached();
+    Recycled { value: RecycledInner::new(&*self.values, t) }
+  }
+
+  #[inline(always)] 
+  pub fn new_from<A>(&self, source: A) -> Recycled<T> where T: InitializeWith<A> {
+    let t = self.detached();
+    Recycled { value: RecycledInner::new_from(&*self.values, t, source) }
+  }
+
+  #[inline] 
+  pub fn detached(&self) -> T {
     match self.values.borrow_mut().pop() {
       Some(v) => v,
       None => T::new()
@@ -167,21 +270,8 @@ impl <T> Pool <T> where T: Recycleable {
   }
 
   #[inline] 
-  pub fn new(&mut self) -> Recycled<T> {
-    let t = self.detached();
-    let pool_reference = self.values.clone();
-    Recycled::new(pool_reference, t)
-  }
- 
-  #[inline(always)] 
-  pub fn new_from<A>(&mut self, source: A) -> Recycled<T> where T: InitializeWith<A> {
-    let t = self.detached();
-    let pool_reference = self.values.clone();
-    Recycled::new_from(pool_reference, t, source)
-  }
-
-  #[inline] 
   pub fn size(&self) -> usize {
-    self.values.borrow().len()
+    (*self.values).borrow().len()
   }
 }
+  

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -2,19 +2,19 @@ extern crate lifeguard;
 
 #[cfg(test)]
 mod tests {
-  use lifeguard::{Pool, Recycled};
+  use lifeguard::{Pool, RcRecycled, Recycled};
 
   #[test]
   fn test_deref() {
-      let mut str_pool : Pool<String> = Pool::with_size(1);
-      let rstring = str_pool.new_from("cat");
+      let str_pool : Pool<String> = Pool::with_size(1);
+      let rstring = str_pool.new_rc_from("cat");
       assert_eq!("cat", *rstring);
   }
 
   #[test]
   fn test_deref_mut() {
-      let mut str_pool : Pool<String> = Pool::with_size(1);
-      let mut rstring = str_pool.new_from("cat");
+      let str_pool : Pool<String> = Pool::with_size(1);
+      let mut rstring = str_pool.new_rc_from("cat");
       rstring.push_str("s love eating mice");
       println!("{}", *rstring);
       assert_eq!("cats love eating mice", *rstring);
@@ -22,25 +22,25 @@ mod tests {
 
   #[test]
   fn test_as_mut() {
-      let mut str_pool : Pool<String> = Pool::with_size(1);
-      let mut rstring = str_pool.new_from("cat");
+      let str_pool : Pool<String> = Pool::with_size(1);
+      let mut rstring = str_pool.new_rc_from("cat");
       rstring.as_mut().push_str("s love eating mice");
       assert_eq!("cats love eating mice", *rstring);
   }
 
   #[test]
   fn test_as_ref() {
-      let mut str_pool : Pool<String> = Pool::with_size(1);
-      let rstring = str_pool.new_from("cat");
+      let str_pool : Pool<String> = Pool::with_size(1);
+      let rstring = str_pool.new_rc_from("cat");
       assert_eq!("cat", rstring.as_ref());
   }
 
   #[test]
   fn test_recycle() {
-      let mut str_pool : Pool<String> = Pool::with_size(1);
+      let str_pool : Pool<String> = Pool::with_size(1);
       {
         assert_eq!(1, str_pool.size());
-        let _rstring = str_pool.new_from("cat");
+        let _rstring = str_pool.new_rc_from("cat");
         assert_eq!(0, str_pool.size());
       }
       assert_eq!(1, str_pool.size());
@@ -48,18 +48,40 @@ mod tests {
 
   #[test]
   fn test_detached() {
-      let mut str_pool : Pool<String> = Pool::with_size(1);
+      let str_pool : Pool<String> = Pool::with_size(1);
       {
         assert_eq!(1, str_pool.size());
-        let _string : String = str_pool.new().detach();
+        let _string : String = str_pool.new_rc().detach();
         assert_eq!(0, str_pool.size());
       }
       assert_eq!(0, str_pool.size());
   }
 
   #[test]
+  fn test_attach_rc() {
+      let str_pool : Pool<String> = Pool::with_size(1);
+      {
+        assert_eq!(1, str_pool.size());
+        let string: String = str_pool.new_rc().detach();
+        assert_eq!(0, str_pool.size());
+        let _rstring: RcRecycled<String> = str_pool.attach_rc(string);
+      }
+      assert_eq!(1, str_pool.size());
+  }
+  #[test]
   fn test_attach() {
-      let mut str_pool : Pool<String> = Pool::with_size(1);
+      let str_pool : Pool<String> = Pool::with_size(1);
+      {
+        assert_eq!(1, str_pool.size());
+        let string: String = str_pool.new().detach();
+        assert_eq!(0, str_pool.size());
+        let _rstring: Recycled<String> = str_pool.attach(string);
+      }
+      assert_eq!(1, str_pool.size());
+  }
+  #[test]
+  fn test_attach_from_rc() {
+      let str_pool : Pool<String> = Pool::with_size(1);
       {
         assert_eq!(1, str_pool.size());
         let string: String = str_pool.new().detach();


### PR DESCRIPTION
I gave implementing scoped allocation a shot since I had an idea about how allow Recycled objects with both & and Rc without duplicating any code. I think it turned other rather good but I wanted to get some feedback before proceeding. One nice thing of this implementation is how the Rc based pool can allocate both Recycled and ScopedRecycled.

The code will still need some cleanup, some tests and benchmarks added, and I think it may be a good idea to make ScopedPool etc newtypes as well to avoid their internal implementation leaking out.
