### PR TITLE
Implemented new_from(Iterator<T>) for Vec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,15 @@ impl <A> InitializeWith<A> for String where A : AsRef<str> {
   }
 }
 
+impl <I, T> InitializeWith<I> for Vec<T> where I: Iterator<Item=T>{
+    #[inline]
+    fn initialize_with(&mut self, source: I) {
+        for it in source{
+            self.push(it);
+        }
+    }
+}
+
 /// A smartpointer which uses a shared reference (`&`) to know
 /// when to move its wrapped value back to the `Pool` that
 /// issued it.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -155,4 +155,17 @@ mod tests {
     assert_eq!(pool.max_size(), 1_024);
     assert_eq!(pool.new().capacity(), 16_000);
   }
+
+  #[test]
+    fn test_new_from_iter(){
+        let vec_pool : Pool<Vec<i32>> = Pool::with_size(1);
+        {
+            let vec4 = vec_pool.new_from(0..4);
+            assert_eq!(4, vec4.len())
+        }
+        {
+            let vec3 = vec_pool.new_from(0..3);
+            assert_eq!(3, vec3.len())
+        }
+    }
 }


### PR DESCRIPTION
This adds support for creating Vectors form Iterators using new_from.

The envisioned use case if replacing calls to collect. ie:

```
(1..2).collect::<Vec<i32>>()
```

becomes

```
pool.new_from(1..2)
```
